### PR TITLE
Fix unused result

### DIFF
--- a/src/spasm_certificate.c
+++ b/src/spasm_certificate.c
@@ -260,12 +260,12 @@ bool spasm_rank_certificate_load(FILE *f, struct spasm_rank_certificate *proof)
 		proof->hash[i] = strtoul(byte, NULL, 16);
 	}
 	for (int k = 0; k < r; k++)
-		if (NULL == fscanf(f, "%d", &proof->i[k])) return 0;
+		if (1 != fscanf(f, "%d", &proof->i[k])) return 0;
 	for (int k = 0; k < r; k++)
-		if (NULL == fscanf(f, "%d", &proof->i[k])) return 0;
+		if (1 != fscanf(f, "%d", &proof->i[k])) return 0;
 	for (int k = 0; k < r; k++)
-		if (NULL == fscanf(f, "%d", &proof->x[k])) return 0;
+		if (1 != fscanf(f, "%d", &proof->x[k])) return 0;
 	for (int k = 0; k < r; k++)
-		if (NULL == fscanf(f, "%d", &proof->y[k])) return 0;
+		if (1 != fscanf(f, "%d", &proof->y[k])) return 0;
 	return 1;
 }

--- a/src/spasm_certificate.c
+++ b/src/spasm_certificate.c
@@ -260,12 +260,12 @@ bool spasm_rank_certificate_load(FILE *f, struct spasm_rank_certificate *proof)
 		proof->hash[i] = strtoul(byte, NULL, 16);
 	}
 	for (int k = 0; k < r; k++)
-		fscanf(f, "%d", &proof->i[k]);
+		if (NULL == fscanf(f, "%d", &proof->i[k])) return 0;
 	for (int k = 0; k < r; k++)
-		fscanf(f, "%d", &proof->i[k]);
+		if (NULL == fscanf(f, "%d", &proof->i[k])) return 0;
 	for (int k = 0; k < r; k++)
-		fscanf(f, "%d", &proof->x[k]);
+		if (NULL == fscanf(f, "%d", &proof->x[k])) return 0;
 	for (int k = 0; k < r; k++)
-		fscanf(f, "%d", &proof->y[k]);
+		if (NULL == fscanf(f, "%d", &proof->y[k])) return 0;
 	return 1;
 }


### PR DESCRIPTION
For the recent compiler I use, fscanf is flagged with attribute 'warn_unused_result' and triggers a compilation error.