### PR TITLE
Added hook for log messages

### DIFF
--- a/src/spasm.h
+++ b/src/spasm.h
@@ -161,6 +161,8 @@ u32 spasm_prng_u32(spasm_prng_ctx *ctx);
 spasm_ZZp spasm_prng_ZZp(spasm_prng_ctx *ctx);
 
 /* spasm_util.c */
+extern int (*logcallback)(char *);
+int logprintf(char *format, ...);
 double spasm_wtime();
 i64 spasm_nnz(const struct spasm_csr * A);
 void *spasm_malloc(i64 size);

--- a/src/spasm_io.c
+++ b/src/spasm_io.c
@@ -93,7 +93,7 @@ struct spasm_triplet *spasm_triplet_load(FILE * f, i64 prime, u8 *hash)
 		if (sscanf(buffer, "%d %d %" SCNd64 "\n", &i, &j, &nnz) != 3)
 			errx(1, "[spasm_triplet_load] bad MatrixMarking dimensions (line %" PRId64 ")\n", line);
 		spasm_human_format(nnz, hnnz);
-		fprintf(stderr, "[IO] loading %d x %d MatrixMarket matrix modulo %" PRId64 " with %s non-zero... ", 
+		logprintf("[IO] loading %d x %d MatrixMarket matrix modulo %" PRId64 " with %s non-zero... ", 
 			i, j, prime, hnnz);
 		fflush(stderr);
 	} else {
@@ -103,7 +103,7 @@ struct spasm_triplet *spasm_triplet_load(FILE * f, i64 prime, u8 *hash)
 			errx(1, "[spasm_triplet_load] bad SMS file (header)\n");
 		if (prime != -1 && type != 'M')
 			errx(1, "[spasm_triplet_load] only ``Modular'' type supported\n");
-		fprintf(stderr, "[IO] loading %d x %d SMS matrix modulo %" PRId64 "... ", i, j, prime);
+		logprintf("[IO] loading %d x %d SMS matrix modulo %" PRId64 "... ", i, j, prime);
 		fflush(stderr);
 	}
 
@@ -143,17 +143,17 @@ struct spasm_triplet *spasm_triplet_load(FILE * f, i64 prime, u8 *hash)
 	if (!mm) {
 		spasm_triplet_realloc(T, -1);
 		spasm_human_format(T->nz, hnnz);
-		fprintf(stderr, "%s non-zero [%.1fs]\n", hnnz, spasm_wtime() - start);
+		logprintf("%s non-zero [%.1fs]\n", hnnz, spasm_wtime() - start);
 	} else {
-		fprintf(stderr, "[%.1fs]\n", spasm_wtime() - start);
+		logprintf("[%.1fs]\n", spasm_wtime() - start);
 	}
 
 	if (ctx != NULL) {
 		spasm_SHA256_final(hash, ctx);
-		fprintf(stderr, "[spasm_triplet_load] sha256(matrix) = ");
+		logprintf("[spasm_triplet_load] sha256(matrix) = ");
 		for (int i = 0; i < 32; i++)
-			fprintf(stderr, "%02x", hash[i]);
-		fprintf(stderr, " / size = %" PRId64" bytes\n", (((i64) ctx->Nh) << 29) + ctx->Nl / 8);
+			logprintf("%02x", hash[i]);
+		logprintf(" / size = %" PRId64" bytes\n", (((i64) ctx->Nh) << 29) + ctx->Nl / 8);
 	}
 	return T;
 }
@@ -250,7 +250,7 @@ void spasm_save_pnm(const struct spasm_csr *A, FILE *f, int x, int y, int mode, 
 		limits_h[1] = ((long long int) cc[3]) * ((long long int) x) / ((long long int) m);
 		limits_v[0] = ((long long int) rr[1]) * ((long long int) y) / ((long long int) n);
 		limits_v[1] = ((long long int) rr[2]) * ((long long int) y) / ((long long int) n);
-		fprintf(stderr, "limits_v = %d, %d\n", limits_v[0], limits_v[1]);
+		logprintf("limits_v = %d, %d\n", limits_v[0], limits_v[1]);
 		r = DM->r;
 		c = DM->c;
 	}

--- a/src/spasm_kernel.c
+++ b/src/spasm_kernel.c
@@ -16,7 +16,7 @@ struct spasm_csr * spasm_kernel(const struct spasm_lu *fact)
 	assert(n <= m);
 	char hnnz[8];
 	spasm_human_format(spasm_nnz(U), hnnz);
-	fprintf(stderr, "[kernel] start. U is %d x %d (%s nnz). Transposing U\n", n, m, hnnz);
+	logprintf("[kernel] start. U is %d x %d (%s nnz). Transposing U\n", n, m, hnnz);
 	double start_time = spasm_wtime();
 
 	struct spasm_csr *Ut = spasm_transpose(U, true);
@@ -73,7 +73,7 @@ struct spasm_csr * spasm_kernel(const struct spasm_lu *fact)
 					while (writing > 0) {
 						#pragma omp flush(writing)
 					}
-					fprintf(stderr, "increasing K; %" PRId64 " ---> %" PRId64 "\n", K->nzmax, 2 * K->nzmax + row_nz);
+					logprintf("increasing K; %" PRId64 " ---> %" PRId64 "\n", K->nzmax, 2 * K->nzmax + row_nz);
 					spasm_csr_realloc(K, 2 * K->nzmax + row_nz);
 					Kj = K->j;
 					Kx = K->x;
@@ -110,7 +110,7 @@ struct spasm_csr * spasm_kernel(const struct spasm_lu *fact)
 			if (tid == 0) {
 				char hnnz[8];
 				spasm_human_format(nnz, hnnz);
-	  			fprintf(stderr, "\rkernel: %d/%d, |K| = %s    ", Kn, m-n, hnnz);
+	  			logprintf("\rkernel: %d/%d, |K| = %s    ", Kn, m-n, hnnz);
 	  			fflush(stderr);
 	  		}
 		}
@@ -118,11 +118,11 @@ struct spasm_csr * spasm_kernel(const struct spasm_lu *fact)
 		free(xj);
 	}
 
-	fprintf(stderr, "\n");
+	logprintf("\n");
 	free(Utqinv);
 	spasm_csr_free(Ut);
 	spasm_human_format(spasm_nnz(K), hnnz);
-	fprintf(stderr, "[kernel] done in %.1fs. NNZ(K) = %s\n", spasm_wtime() - start_time, hnnz);
+	logprintf("[kernel] done in %.1fs. NNZ(K) = %s\n", spasm_wtime() - start_time, hnnz);
 	return K;
 }
 

--- a/src/spasm_matching.c
+++ b/src/spasm_matching.c
@@ -124,10 +124,10 @@ int spasm_maximum_matching(const struct spasm_csr *A, int *p, int *qinv)
 	for (int i = 0; (i < n) && (k < r); i++) {
 		if (p[i] < 0)
 			k += spasm_augmenting_path(A, i, istack, jstack, pstack, marks, plookahead, p, qinv);
-		fprintf(stderr, "\r[matching] %d / %d, size %d", i, n, k);
+		logprintf("\r[matching] %d / %d, size %d", i, n, k);
 		fflush(stderr);
 	}
-	fprintf(stderr, " [%.1f s]\n", spasm_wtime() - start);
+	logprintf(" [%.1f s]\n", spasm_wtime() - start);
 	free(istack);
 	free(jstack);
 	free(pstack);

--- a/src/spasm_pivots.c
+++ b/src/spasm_pivots.c
@@ -61,7 +61,7 @@ static int spasm_find_FL_pivots(const struct spasm_csr *A, int *p, int *qinv)
 		if (qinv[j] == -1 || spasm_row_weight(A, i) < spasm_row_weight(A, qinv[j]))
 			npiv += register_pivot(i, j, p, qinv);
 	}
-	fprintf(stderr, "[pivots] Faugère-Lachartre: %d pivots found [%.1fs]\n", npiv, spasm_wtime() - start);
+	logprintf("[pivots] Faugère-Lachartre: %d pivots found [%.1fs]\n", npiv, spasm_wtime() - start);
 	return npiv;
 }
 
@@ -116,7 +116,7 @@ static int spasm_find_FL_column_pivots(const struct spasm_csr *A, int *pinv, int
 		}
 	}
 	free(w);
-	fprintf(stderr, "[pivots] ``Faugère-Lachartre on columns'': %d pivots found [%.1fs]\n", 
+	logprintf("[pivots] ``Faugère-Lachartre on columns'': %d pivots found [%.1fs]\n", 
 		npiv, spasm_wtime() - start);
 	return npiv;
 }
@@ -186,7 +186,7 @@ static int spasm_find_cycle_free_pivots(const struct spasm_csr *A, int *pinv, in
 			 *   w[j] ==  0  column j was absent and is unreachable
 			 */
 			if ((tid == 0) && (i % v) == 0) {
-				fprintf(stderr, "\r[pivots] %d / %d --- found %d new", processed, n, npiv);
+				logprintf("\r[pivots] %d / %d --- found %d new", processed, n, npiv);
 				fflush(stderr);
 			}
 			if (pinv[i] >= 0)
@@ -288,7 +288,7 @@ static int spasm_find_cycle_free_pivots(const struct spasm_csr *A, int *pinv, in
 		free(queue);
 	}
 	free(journal);
-	fprintf(stderr, "\r[pivots] greedy alternating cycle-free search: %d pivots found [%.1fs]\n", 
+	logprintf("\r[pivots] greedy alternating cycle-free search: %d pivots found [%.1fs]\n", 
 		npiv, spasm_wtime() - start);
 	return npiv;
 }
@@ -314,7 +314,7 @@ static int spasm_pivots_find(const struct spasm_csr *A, int *pinv, int *qinv, st
 	npiv += spasm_find_FL_column_pivots(A, pinv, qinv);	
 	if (opts->enable_greedy_pivot_search)
 		npiv += spasm_find_cycle_free_pivots(A, pinv, qinv);
-	fprintf(stderr, "\r[pivots] %d pivots found\n", npiv);
+	logprintf("\r[pivots] %d pivots found\n", npiv);
 	return npiv;
 }
 
@@ -421,7 +421,7 @@ int spasm_pivots_extract_structural(const struct spasm_csr *A, const int *p_in, 
 		if (L != NULL) {
 			int i_out = (p_in != NULL) ? p_in[i] : i;
 			spasm_add_entry(L, i_out, U->n, pivot);
-			// fprintf(stderr, "Adding L[%d, %d] = %d\n", i_out, U->n, pivot);
+			// logprintf("Adding L[%d, %d] = %d\n", i_out, U->n, pivot);
 			Lp[U->n] = i_out;
 		}
 

--- a/src/spasm_rref.c
+++ b/src/spasm_rref.c
@@ -29,7 +29,7 @@ struct spasm_csr * spasm_rref(const struct spasm_lu *fact, int *Rqinv)
 	i64 prime = spasm_get_prime(U);
 	char hnnz[8];
 	spasm_human_format(spasm_nnz(U), hnnz);
-	fprintf(stderr, "[rref] start. U is %d x %d (%s nnz)\n", n, m, hnnz);
+	logprintf("[rref] start. U is %d x %d (%s nnz)\n", n, m, hnnz);
 	double start_time = spasm_wtime();
 	struct spasm_csr *R = spasm_csr_alloc(n, m, spasm_nnz(U), prime, true);
 	i64 *Rp = R->p;
@@ -120,7 +120,7 @@ struct spasm_csr * spasm_rref(const struct spasm_lu *fact, int *Rqinv)
 			if (tid == 0) {
 				char hnnz[8];
 				spasm_human_format(nnz, hnnz);
-	  			fprintf(stderr, "\rRREF: %d/%d, |R| = %s    ", Rn, n, hnnz);
+	  			logprintf("\rRREF: %d/%d, |R| = %s    ", Rn, n, hnnz);
 	  			fflush(stderr);
 	  		}
 		}
@@ -139,9 +139,9 @@ struct spasm_csr * spasm_rref(const struct spasm_lu *fact, int *Rqinv)
 			Rqinv[j] = i;
 		}
 	}
-	fprintf(stderr, "\n");
+	logprintf("\n");
 
 	spasm_human_format(spasm_nnz(R), hnnz);
-	fprintf(stderr, "[rref] done in %.1fs. NNZ(R) = %s\n", spasm_wtime() - start_time, hnnz);
+	logprintf("[rref] done in %.1fs. NNZ(R) = %s\n", spasm_wtime() - start_time, hnnz);
 	return R;
 }

--- a/src/spasm_schur.c
+++ b/src/spasm_schur.c
@@ -165,7 +165,7 @@ struct spasm_csr *spasm_schur(const struct spasm_csr *A, const int *p, int n, co
 					Li[local_lnz] = i_orig;
 					Lj[local_lnz] = qinv[j];
 					Lx[local_lnz] = x[j];
-					// fprintf(stderr, "Adding L[%d, %d] = %d\n", i_out, qinv[j], x[j]);
+					// logprintf("Adding L[%d, %d] = %d\n", i_out, qinv[j], x[j]);
 					local_lnz += 1;
 				}
 			}
@@ -176,7 +176,7 @@ struct spasm_csr *spasm_schur(const struct spasm_csr *A, const int *p, int n, co
 
 			if (tid == 0 && (i % verbose_step) == 0) {
 				double density =  1.0 * snz / (1.0 * m * Sn);
-				fprintf(stderr, "\rSchur complement: %d/%d [%" PRId64 " nz / density= %.3f]", Sn, n, snz, density);
+				logprintf("\rSchur complement: %d/%d [%" PRId64 " nz / density= %.3f]", Sn, n, snz, density);
 				fflush(stderr);
 			}
 		}
@@ -188,7 +188,7 @@ struct spasm_csr *spasm_schur(const struct spasm_csr *A, const int *p, int n, co
 		L->nz = lnz;
 	spasm_csr_realloc(S, -1);
 	double density = 1.0 * snz / (1.0 * m * n);
-	fprintf(stderr, "\rSchur complement: %d * %d [%" PRId64 " nz / density= %.3f], %.1fs\n", n, m, snz, density, spasm_wtime() - start);
+	logprintf("\rSchur complement: %d * %d [%" PRId64 " nz / density= %.3f], %.1fs\n", n, m, snz, density, spasm_wtime() - start);
 	return S;
 }
 
@@ -263,7 +263,7 @@ void spasm_schur_dense(const struct spasm_csr *A, const int *p, int n, const int
 	int m = A->m;
 	int Sm = m - U->n;                                   /* #columns of S */
 	prepare_q(m, qinv, q);                               /* FIXME: useless if many invokations */
-	fprintf(stderr, "[schur/dense] dimension %d x %d...\n", n, Sm);
+	logprintf("[schur/dense] dimension %d x %d...\n", n, Sm);
 	double start = spasm_wtime();
 	int verbose_step = spasm_max(1, n / 1000);
 	int r = 0;
@@ -322,14 +322,14 @@ void spasm_schur_dense(const struct spasm_csr *A, const int *p, int n, const int
 			#pragma omp atomic update
 			r += 1;
 			if (tid == 0 && (r % verbose_step) == 0) {
-				fprintf(stderr, "\r[schur/dense] %d/%d", r, n);
+				logprintf("\r[schur/dense] %d/%d", r, n);
 				fflush(stderr);
 			}
 		}
 		free(x);
 		free(xj);
 	}
-	fprintf(stderr, "\n[schur/dense] finished in %.1fs, rank <= %d\n", spasm_wtime() - start, r);
+	logprintf("\n[schur/dense] finished in %.1fs, rank <= %d\n", spasm_wtime() - start, r);
 }
 
 
@@ -354,7 +354,7 @@ void spasm_schur_dense_randomized(const struct spasm_csr *A, const int *p, int n
 	const i64 *Up = U->p;
 	const int *Uj = U->j;
 	prepare_q(m, qinv, q);
-	fprintf(stderr, "[schur/dense/random] dimension %d x %d, weight %d...\n", N, Sm, w);
+	logprintf("[schur/dense/random] dimension %d x %d, weight %d...\n", N, Sm, w);
 	double start = spasm_wtime();
 	int verbose_step = spasm_max(1, N / 1000);
 
@@ -403,11 +403,11 @@ void spasm_schur_dense_randomized(const struct spasm_csr *A, const int *p, int n
 
 			/* verbosity */
 			if ((k % verbose_step) == 0) {
-				fprintf(stderr, "\r[schur/dense/random] %" PRId64 "/%d", k, N);
+				logprintf("\r[schur/dense/random] %" PRId64 "/%d", k, N);
 				fflush(stderr);
 			}
 		}
 		free(y);
 	}
-	fprintf(stderr, "\n[schur/dense/random] finished in %.1fs\n", spasm_wtime() - start);
+	logprintf("\n[schur/dense/random] finished in %.1fs\n", spasm_wtime() - start);
 }

--- a/src/spasm_triplet.c
+++ b/src/spasm_triplet.c
@@ -106,7 +106,7 @@ struct spasm_csr *spasm_compress(const struct spasm_triplet * T)
 	spasm_ZZp *Tx = T->x;
 	
 	double start = spasm_wtime();
-	fprintf(stderr, "[CSR] Compressing... ");
+	logprintf("[CSR] Compressing... ");
 	fflush(stderr);
 
 	/* allocate result */
@@ -153,6 +153,6 @@ struct spasm_csr *spasm_compress(const struct spasm_triplet * T)
 	char mem[16];
 	int size = sizeof(int) * (n + nz) + sizeof(spasm_ZZp) * ((Cx != NULL) ? nz : 0);
 	spasm_human_format(size, mem);
-	fprintf(stderr, "%" PRId64 " actual NZ, Mem usage = %sbyte [%.2fs]\n", spasm_nnz(C), mem, spasm_wtime() - start);
+	logprintf("%" PRId64 " actual NZ, Mem usage = %sbyte [%.2fs]\n", spasm_nnz(C), mem, spasm_wtime() - start);
 	return C;
 }

--- a/src/spasm_util.c
+++ b/src/spasm_util.c
@@ -4,8 +4,23 @@
 #include <sys/time.h>
 #include <err.h>
 #include <inttypes.h>
+#include <stdarg.h>
 
 #include "spasm.h"
+
+int (*logcallback)(char *) = NULL;
+
+int logprintf(char *format, ...) {
+  va_list args;
+  va_start(args, format);
+
+  if (logcallback) {
+    char s[1000];
+    vsnprintf(s, 1000, format, args);
+    return (*logcallback)(s);
+  } else
+    return vfprintf(stderr, format, args);
+}
 
 int spasm_get_num_threads() {
 #ifdef _OPENMP
@@ -140,12 +155,12 @@ void spasm_triplet_realloc(struct spasm_triplet *A, i64 nzmax)
 {
 	if (nzmax < 0)
 		nzmax = A->nz;
-	// fprintf(stderr, "[realloc] nzmax=%ld. before %px %px %px\n", nzmax, A->i, A->j, A->x);
+	// logprintf("[realloc] nzmax=%ld. before %px %px %px\n", nzmax, A->i, A->j, A->x);
 	A->i = spasm_realloc(A->i, nzmax * sizeof(int));
 	A->j = spasm_realloc(A->j, nzmax * sizeof(int));
 	if (A->x != NULL)
 		A->x = spasm_realloc(A->x, nzmax * sizeof(spasm_ZZp));
-	// fprintf(stderr, "[realloc] after %px %px %px\n", A->i, A->j, A->x);
+	// logprintf("[realloc] after %px %px %px\n", A->i, A->j, A->x);
 	A->nzmax = nzmax;
 }
 


### PR DESCRIPTION
For use of Spasm as a library, I replaced the "fprintf(stderr,..." by calls to "logprintf(...)" which defaults to fprintf(stderr) but can be set to call back a function.